### PR TITLE
Add retry controls for Gemini panels after errors

### DIFF
--- a/components/EvidenceBoard.tsx
+++ b/components/EvidenceBoard.tsx
@@ -67,6 +67,13 @@ const CaseBoard: React.FC<CaseBoardProps> = ({ destination, evidenceItems }) => 
     }
   }, [destination, evidenceItems]);
 
+  const handleRetry = useCallback(() => {
+    setSummary('');
+    setError('');
+    setIsGenerated(false);
+    generateSummary();
+  }, [generateSummary]);
+
   const renderFormattedText = (text: string) => {
     return text.split('\n').map((line, i) => {
         const parts = line.split('**');
@@ -118,7 +125,18 @@ const CaseBoard: React.FC<CaseBoardProps> = ({ destination, evidenceItems }) => 
         ) : (
             <div className="bg-white p-4 rounded-md border border-slctrips-mid min-h-[150px]">
                  {isLoading && !summary && <SkeletonLoader />}
-                 {!isLoading && error && <ErrorDisplay message={error} />}
+                 {!isLoading && error && (
+                    <div className="space-y-3">
+                        <ErrorDisplay message={error} />
+                        <button
+                            onClick={handleRetry}
+                            disabled={isLoading}
+                            className="w-full bg-slctrips-navy text-white font-semibold py-2 px-4 rounded-md hover:bg-slctrips-black disabled:bg-slate-400 transition-colors duration-300"
+                        >
+                            Try Again
+                        </button>
+                    </div>
+                 )}
 
                  <div className="prose prose-sm max-w-none text-slctrips-black">
                     {renderFormattedText(summary)}

--- a/components/FieldInvestigationKit.tsx
+++ b/components/FieldInvestigationKit.tsx
@@ -77,6 +77,13 @@ const InvestigationPlanner: React.FC<InvestigationPlannerProps> = ({ destination
       setIsLoading(false);
     }
   }, [destination, focus, duration]);
+
+  const handleRetry = useCallback(() => {
+    setItinerary('');
+    setError('');
+    setIsGenerated(false);
+    generateItinerary();
+  }, [generateItinerary]);
   
   const renderFormattedText = (text: string) => {
     return text.split('\n').map((line, i) => {
@@ -155,7 +162,20 @@ const InvestigationPlanner: React.FC<InvestigationPlannerProps> = ({ destination
             {isLoading && itinerary && <span className="inline-block w-2 h-4 bg-slctrips-sky animate-pulse ml-1"></span>}
           </div>
 
-          {error && <ErrorDisplay message={error} />}
+          {error && (
+            <div className="space-y-3">
+              <ErrorDisplay message={error} />
+              {!isLoading && (
+                <button
+                  onClick={handleRetry}
+                  disabled={isLoading}
+                  className="w-full bg-slctrips-sky text-white font-bold py-2 px-4 rounded-lg hover:bg-slctrips-navy disabled:bg-slate-400 transition-colors duration-300"
+                >
+                  Try Again
+                </button>
+              )}
+            </div>
+          )}
           
           {!isLoading && !error && (
             <button

--- a/components/GeminiMissionBriefing.tsx
+++ b/components/GeminiMissionBriefing.tsx
@@ -117,7 +117,20 @@ const GeminiCaseBriefing: React.FC<GeminiCaseBriefingProps> = ({ destination }) 
                  {isLoading && briefing && <span className="inline-block w-2 h-4 bg-slctrips-gold animate-pulse ml-1"></span>}
             </div>
 
-            {error && <ErrorDisplay message={error} />}
+            {error && (
+                <div className="mt-4 space-y-3">
+                    <ErrorDisplay message={error} />
+                    {!isLoading && (
+                        <button
+                            onClick={generateBriefing}
+                            disabled={isLoading}
+                            className="bg-slctrips-gold text-slctrips-navy font-bold py-2 px-6 rounded-full hover:bg-yellow-300 disabled:bg-slate-600 transition-colors duration-300"
+                        >
+                            Try Again
+                        </button>
+                    )}
+                </div>
+            )}
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- keep the AI briefing action accessible after failures by surfacing a retry button outside of active loads
- add a planner retry handler that clears stale itinerary data before triggering a new request
- allow the evidence board to re-run profiler analysis when Gemini responses error out

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0cb712844832ca3cbac96dfbc5bff